### PR TITLE
Properly check for existing installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Find pdfreactor directory
   find:
     paths: "{{ PDF_REACTOR_INSTALL_DIR }}"
-    patterns: ""
+    patterns: "PDFreactor"
     file_type: "directory"
   register: PDF_reactor_exist
 
@@ -11,33 +11,35 @@
     state: absent
     path: "{{PDF_REACTOR_INSTALL_DIR}}/bin/error.log"
 
-- name: Download PDFReactor
-  get_url: 
-    url: "{{ PDF_REACTOR_URL }}/{{ PDF_REACTOR_FILE }}"
-    dest: "/tmp/{{ PDF_REACTOR_FILE }}"
-    timeout: 60
-    use_proxy: true
+- block:
+  - name: Download PDFReactor
+    get_url:
+      url: "{{ PDF_REACTOR_URL }}/{{ PDF_REACTOR_FILE }}"
+      dest: "/tmp/{{ PDF_REACTOR_FILE }}"
+      timeout: 60
+      use_proxy: true
+
+  - name: Untar PDFReactor
+    unarchive:
+      src: "/tmp/{{ PDF_REACTOR_FILE }}"
+      dest: "{{ PDF_REACTOR_INSTALL_DIR }}"
+      copy: no
+      creates: "{{ PDF_REACTOR_INSTALL_DIR }}/PDFreactor/*"
+
+  - name: Create pdfreactorwebservice symlink
+    file:
+      src: "{{ PDF_REACTOR_INSTALL_DIR }}/PDFreactor/bin/pdfreactorwebservice"
+      dest: "/etc/init.d/pdfreactorwebservice"
+      owner: root
+      group: root
+      state: link
+
+  - name: Clean up install file
+    file:
+      state: absent
+      path: "/tmp/{{ PDF_REACTOR_FILE }}"
+
   when: "PDF_reactor_exist.matched == 0"
-
-- name: Untar PDFReactor
-  unarchive: 
-    src: "/tmp/{{ PDF_REACTOR_FILE }}"
-    dest: "{{ PDF_REACTOR_INSTALL_DIR }}" 
-    copy: no
-    creates: "{{ PDF_REACTOR_INSTALL_DIR }}/PDFreactor/*"
-
-- name: Create pdfreactorwebservice symlink
-  file:
-    src: "{{ PDF_REACTOR_INSTALL_DIR }}/PDFreactor/bin/pdfreactorwebservice"
-    dest: "/etc/init.d/pdfreactorwebservice"
-    owner: root
-    group: root
-    state: link
 
 - name: Start and enable pdfreactor
   service: name=pdfreactorwebservice state=started enabled=yes
-
-- name: Clean up install file
-  file:
-    state: absent
-    path: "/tmp/{{ PDF_REACTOR_FILE }}"


### PR DESCRIPTION
The existing logic fails to properly detect an existing installation of PDFReactor. The [existing logic](https://github.com/cfpb/ansible-pdf-reactor/blob/84a1443a18b5ee8c9cb29d8486fffc55abe169c3/tasks/main.yml#L2) is:

```yaml
- name: Find pdfreactor directory
  find:
    paths: "{{ PDF_REACTOR_INSTALL_DIR }}"
    patterns: ""
    file_type: "directory"
  register: PDF_reactor_exist
```

to look for an empty (`""`) directory in `PDF_REACTOR_INSTALL_DIR` which is actually [defined as](https://github.com/vccabral/ansible-pdf-reactor/blob/b2654803adc6bc06a97b55dafca600007a034b02/defaults/main.yml#L4) `/opt`. This fails to detect an existing `PDFreactor` subdirectory there.

This PR changes the logic to instead use:

```yaml
- name: Find pdfreactor directory
   find:
     paths: "{{ PDF_REACTOR_INSTALL_DIR }}"
     patterns: "PDFreactor"
     file_type: "directory"
   register: PDF_reactor_exist
```

This properly detects the presence of `/opt/PDFreactor`.

I've also modified the logic so that all of these steps are now gated by the test for the existing directory:

1. Download install archive
2. Untar install archive
3. Create symlink
4. Delete install archive

Whether the install happens or not, the playbook still always ensures that the webservice is running and cleans up the error log.

@imuchnik 