### PR TITLE
delete PDFReactor samples

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,3 +43,9 @@
 
 - name: Start and enable pdfreactor
   service: name=pdfreactorwebservice state=started enabled=yes
+
+- name: Delete examples
+  file:
+    state: absent
+    path: "{{PDF_REACTOR_INSTALL_DIR}}/samples"
+


### PR DESCRIPTION
A security finding recommends that we delete the 'samples' directory.